### PR TITLE
Simplify room admin and fix fetch

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,12 +61,7 @@ body {
                 </div>
                 <button type="submit" class="btn btn-primary">Add Room</button>
             </form>
-            <div class="mb-3">
-                <label for="roomFile" class="form-label">Import Rooms JSON</label>
-                <input type="file" id="roomFile" class="form-control">
-            </div>
             <pre id="roomOutput" class="bg-dark p-2 text-white"></pre>
-            <button type="button" id="downloadRooms" class="btn btn-secondary mt-2">Download JSON</button>
         </div>
         <div class="tab-pane fade" id="settings" role="tabpanel" aria-labelledby="settings-tab">
             <h5>General Settings</h5>
@@ -104,30 +99,6 @@ document.getElementById("roomForm").addEventListener("submit",function(e){
     rooms.push(room);
     this.reset();
     renderRooms();
-});
-
-document.getElementById("roomFile").addEventListener("change",function(){
-    const file=this.files[0];
-    if(!file) return;
-    const reader=new FileReader();
-    reader.onload=e=>{
-        try{
-            const data=JSON.parse(e.target.result);
-            loadRooms(data);
-        }catch(err){
-            alert("Invalid JSON");
-        }
-    };
-    reader.readAsText(file);
-});
-
-document.getElementById("downloadRooms").addEventListener("click",function(){
-    const blob=new Blob([JSON.stringify({rooms:rooms},null,2)],{type:"application/json"});
-    const a=document.createElement("a");
-    a.href=URL.createObjectURL(blob);
-    a.download="rooms.json";
-    a.click();
-    URL.revokeObjectURL(a.href);
 });
 </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@ body {
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 <script>
-fetch('rooms.json')
+fetch(new URL('rooms.json', window.location.href))
   .then(r => r.json())
   .then(data => {
     const rooms = Array.isArray(data.rooms) ? data.rooms : data;


### PR DESCRIPTION
## Summary
- remove import/export controls from admin page
- fetch rooms.json using absolute path in index

## Testing
- `tidy --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452a00abdc83299ad405dcb9d56857